### PR TITLE
FOIA-307: Add data to results report.

### DIFF
--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -73,8 +73,9 @@ class AnnualReportStore extends Store {
     if (dataType === null || typeof dataType !== 'object') {
       return false;
     }
+
     if (!Object.prototype.hasOwnProperty.call(dataType, 'field_agency_component')) {
-      return false;
+      return 'Agency Overall';
     }
 
     return dataType.field_agency_component.abbreviation

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -17,6 +17,90 @@ class AnnualReportStore extends Store {
     return this.state;
   }
 
+  /**
+   * Gets a report by id from the data store.
+   *
+   * @param {string} reportId
+   *   The report id from the jsonapi data.
+   * @returns {Map | boolean}
+   *   A Map containing the report data from the api or false if it doesn't not exist.
+   */
+  getReport(reportId) {
+    return this.state.reports.get(reportId) || false;
+  }
+
+  /**
+   * Get a report's agency abbreviation by report id.
+   *
+   * @param {string} reportId
+   *   The report id from the jsonapi data.
+   * @returns {boolean|string}
+   *   The reporting agency's abbreviation or false, if the agency or abbreviation cannot be found.
+   */
+  getAgency(reportId) {
+    const report = this.getReport(reportId);
+    if (!report) {
+      return false;
+    }
+
+    return report.get('field_agency') && report.get('field_agency').abbreviation
+      ? report.get('field_agency').abbreviation
+      : false;
+  }
+
+  /**
+   * Get a report's fiscal year by report id.
+   *
+   * @param {string} reportId
+   *   The report id from the jsonapi data.
+   * @returns {boolean|string}
+   *   The fiscal year of the report or false if the data cannot be found.
+   */
+  getFiscalYear(reportId) {
+    const report = this.getReport(reportId);
+    return report && report.get('field_foia_annual_report_yr') ? report.get('field_foia_annual_report_yr') : false;
+  }
+
+  /**
+   * Get a dataType's agency component abbreviation.
+   *
+   * @param {Object} dataType
+   *   The section or object containing the agency component field.
+   * @returns {boolean|string}
+   *   The component abbreviation or false if the data cannot be found.
+   */
+  static getComponentAbbreviation(dataType) {
+    if (dataType === null || typeof dataType !== 'object') {
+      return false;
+    }
+    if (!Object.prototype.hasOwnProperty.call(dataType, 'field_agency_component')) {
+      return false;
+    }
+
+    return dataType.field_agency_component.abbreviation
+      ? dataType.field_agency_component.abbreviation
+      : false;
+  }
+
+  /**
+   * Appends report data to a row (component object).
+   *
+   * @param {Object} row
+   *   An object of component data.
+   * @param {string} reportId
+   *   The id of the report that this row belongs to.
+   * @returns {Object}
+   *   A row of component data for the results table, including the reporting agency,
+   *   fiscal year and component abbreviation.
+   */
+  appendReportData(row, reportId) {
+    return Object.assign({}, row, {
+      agency: this.getAgency(reportId),
+      fiscalYear: this.getFiscalYear(reportId),
+      component: AnnualReportStore.getComponentAbbreviation(row),
+    });
+  }
+
   __onDispatch(payload) {
     switch (payload.type) {
       case types.ANNUAL_REPORT_DATA_RECEIVE: {

--- a/js/test/stores/annual_report.test.js
+++ b/js/test/stores/annual_report.test.js
@@ -1,0 +1,86 @@
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { Map } from 'immutable';
+
+import annualReportStore, { AnnualReportStore } from '../../stores/annual_report';
+
+chai.use(sinonChai);
+
+
+describe('FoiaAnnualReportRequestBuilder', () => {
+  let sandbox;
+  const reports = new Map({
+    test_report_1: new Map({
+      title: 'Test Report 1',
+      field_agency: {
+        abbreviation: 'TEST_AGENCY_ABBREVIATION',
+      },
+      field_foia_annual_report_yr: 2018,
+      field_test_component: [{
+        field_agency_component: {
+          abbreviation: 'TEST_COMPONENT',
+        },
+        field_test_field: 'TEST_FIELD_VALUE',
+      }],
+    }),
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(AnnualReportStore.prototype, 'getState').returns({ reports });
+    sandbox.stub(annualReportStore, 'state').value({ reports });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('::getAgency', () => {
+    it('retrieves an agency abbreviation from a report in the store', () => {
+      expect(annualReportStore.getAgency('test_report_1'), 'agency abbreviation').to.equal('TEST_AGENCY_ABBREVIATION');
+    });
+    it('returns false if no report by the given id exists', () => {
+      expect(annualReportStore.getAgency('non_existent_report_id'), 'agency abbreviation').to.equal(false);
+    });
+  });
+
+  describe('::getFiscalYear', () => {
+    it('retrieves the fiscal year from a report in the store', () => {
+      expect(annualReportStore.getFiscalYear('test_report_1'), 'fiscal year').to.equal(2018);
+    });
+    it('returns false if no report by the given id exists', () => {
+      expect(annualReportStore.getFiscalYear('non_existent_report_id'), 'fiscal year').to.equal(false);
+    });
+  });
+
+  describe('::getComponentAbbreviation', () => {
+    it('retrieves a component abbreviation given a component', () => {
+      const report = annualReportStore.getReport('test_report_1');
+      expect(
+        AnnualReportStore.getComponentAbbreviation(
+          report.get('field_test_component')[0],
+        ), 'component abbreviation').to.equal('TEST_COMPONENT');
+    });
+    it('returns false if the agency component or abbreviation fields do not exist ', () => {
+      const report = annualReportStore.getReport('test_report_1');
+      expect(AnnualReportStore.getComponentAbbreviation(
+        report.get('non_existent_component'),
+      ), 'component_abbreviation').to.equal(false);
+    });
+  });
+
+  describe('::appendReportData', () => {
+    it('adds report values to component objects', () => {
+      const component = annualReportStore.getReport('test_report_1').get('field_test_component')[0];
+      expect(annualReportStore.appendReportData(component, 'test_report_1'), 'component & report data')
+        .to
+        .include({
+          field_test_field: 'TEST_FIELD_VALUE',
+          agency: 'TEST_AGENCY_ABBREVIATION',
+          component: 'TEST_COMPONENT',
+          fiscalYear: 2018,
+        });
+    });
+  });
+});

--- a/js/test/stores/annual_report.test.js
+++ b/js/test/stores/annual_report.test.js
@@ -82,5 +82,19 @@ describe('FoiaAnnualReportRequestBuilder', () => {
           fiscalYear: 2018,
         });
     });
+
+    it('defaults to the value "Agency Overall" if the field_agency_component field does not exist in the given row', () => {
+      const component = {
+        overall_field: 'OVERALL FIELD VALUE',
+      };
+      expect(annualReportStore.appendReportData(component, 'test_report_1'), 'overall component & report data')
+        .to
+        .include({
+          overall_field: 'OVERALL FIELD VALUE',
+          agency: 'TEST_AGENCY_ABBREVIATION',
+          component: 'Agency Overall',
+          fiscalYear: 2018,
+        });
+    });
   });
 });


### PR DESCRIPTION
Adds a method to the annual report data store to add report data to
a component row, given a report id and row.