### PR TITLE
FOIA-305: Create api tests.

### DIFF
--- a/js/test/api/annual_foia_report.test.js
+++ b/js/test/api/annual_foia_report.test.js
@@ -1,0 +1,100 @@
+import 'test/setup';
+import { JsonApi } from '../../util/json_api';
+
+describe('FOIA Api', function foiaApiTestScenarios() {
+  // Increasing (default 2000ms) to account for real-world conditions.
+  this.timeout(30000);
+
+  const baseUrl = 'https://uat-api.foia.gov/api';
+  let apiResponse;
+  let apiResponseData;
+
+  const makeRequest = (endpoint, params = {}) => {
+    const api = new JsonApi(baseUrl);
+
+    return api.get(endpoint, { params }).then((response) => {
+      apiResponse = response;
+      apiResponseData = response.data.data;
+      return response;
+    });
+  };
+
+  describe('/annual_foia_report/fiscal_years', () => {
+    before(() => makeRequest('/annual_foia_report/fiscal_years'));
+
+    it('returns a 200 response code.', () => {
+      expect(apiResponse.status).to.equal(200);
+    });
+
+    it('returns an array of multiple values.', () => {
+      expect(apiResponse.data).to.be.an('array');
+      expect(apiResponse.data.length).to.be.greaterThan(1);
+    });
+
+    it('returns numerical years.', () => {
+      apiResponse.data.forEach((raw_value) => {
+        const parsed = parseInt(raw_value, 10);
+        expect(parsed).to.be.greaterThan(0);
+        expect(parsed).to.be.lessThan(3000);
+      });
+    });
+  });
+
+  describe('/agency_components', () => {
+    before(() => makeRequest('/agency_components'));
+
+    it('returns a 200 response code.', () => {
+      expect(apiResponse.status).to.equal(200);
+    });
+
+    it('returns multiple objects in the data array.', () => {
+      expect(apiResponseData).to.be.an('array');
+      expect(apiResponseData.length).to.be.greaterThan(1);
+    });
+
+    it('returns objects of type agency_component.', () => {
+      apiResponseData.forEach((obj) => {
+        expect(obj.type).to.equal('agency_component');
+      });
+    });
+  });
+
+  describe('/annual_foia_report request', () => {
+    before(() => {
+      const endpoint = '/annual_foia_report';
+      const params = {
+        filter: {
+          agencyFilter: {
+            condition: {
+              path: 'field_agency.abbreviation',
+              value: ['USAID'],
+              operator: 'IN',
+            },
+          },
+        },
+      };
+      return makeRequest(endpoint, params);
+    });
+
+    it('returns a 200 response code.', () => {
+      expect(apiResponse.status).to.equal(200);
+    });
+
+    it('returns at least one object in the data array.', () => {
+      expect(apiResponseData).to.be.an('array');
+      expect(apiResponseData.length).to.be.at.least(1);
+    });
+
+    it('returns objects of type agency_component', () => {
+      apiResponseData.forEach((obj) => {
+        expect(obj.type).to.equal('annual_foia_report_data');
+      });
+    });
+
+    it('returns only components belonging to the requested agency', () => {
+      apiResponseData.forEach((obj) => {
+        expect(obj.attributes.field_agency_abbr).to.equal('USAID');
+      });
+    });
+  });
+});

--- a/js/test/api/annual_foia_report.test.js
+++ b/js/test/api/annual_foia_report.test.js
@@ -5,12 +5,11 @@ describe('FOIA Api', function foiaApiTestScenarios() {
   // Increasing (default 2000ms) to account for real-world conditions.
   this.timeout(30000);
 
-  const baseUrl = 'https://uat-api.foia.gov/api';
   let apiResponse;
   let apiResponseData;
 
   const makeRequest = (endpoint, params = {}) => {
-    const api = new JsonApi(baseUrl);
+    const api = new JsonApi();
 
     return api.get(endpoint, { params }).then((response) => {
       apiResponse = response;

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -27,7 +27,7 @@ module.exports = {
     extensions: ['.js', '.jsx', '.json'],
     modules: [path.join(__dirname, 'js'), 'node_modules'],
     alias: {
-      settings$: path.join(__dirname, 'js', 'settings', 'development.js'),
+      settings$: path.join(__dirname, 'js', 'settings', 'uat.js'),
     },
   },
 };


### PR DESCRIPTION
@bemarlan it looks like tests weren't previously loading environment specific config. Since I wasn't sure how we want this to work, I've included a separate commit with changes to webpack.config.test.js (and a corresponding change to the api test to load the base url from config). I'll also bring this up during tomorrow's standup.