### PR TITLE
FOIA-329: CSV download.

### DIFF
--- a/js/actions/report.js
+++ b/js/actions/report.js
@@ -42,6 +42,7 @@ export const types = {
   DATA_TYPE_FIELD_HAS_ERRORS: 'DATA_TYPE_FIELD_HAS_ERRORS',
   FISCAL_YEAR_FIELD_HAS_ERRORS: 'FISCAL_YEAR_FIELD_HAS_ERRORS',
   FORM_HAS_ERRORS: 'FORM_HAS_ERRORS',
+  GET_TABLE_DATA_TYPES: 'GET_TABLE_DATA_TYPES',
 };
 
 // Action creators, to dispatch actions
@@ -217,6 +218,15 @@ export const reportActions = {
   returnFieldValidationStateOnSubmit() {
     dispatcher.dispatch({
       type: types.FORM_HAS_ERRORS,
+    });
+
+    return Promise.resolve();
+  },
+
+  getTableDataTypes(dataTypeOptions) {
+    dispatcher.dispatch({
+      type: types.GET_TABLE_DATA_TYPES,
+      dataTypeOptions,
     });
 
     return Promise.resolve();

--- a/js/components/foia_report_data_type_filter.jsx
+++ b/js/components/foia_report_data_type_filter.jsx
@@ -40,6 +40,7 @@ class FoiaReportDataTypeFilter extends Component {
     });
 
     reportActions.validateDataTypeField(selection);
+    reportActions.getTableDataTypes([...this.props.dataTypeOptions]);
   }
 
   handleFilterFieldUpdate(e) {

--- a/js/components/foia_report_results_table.jsx
+++ b/js/components/foia_report_results_table.jsx
@@ -39,15 +39,15 @@ class FoiaReportResultsTable extends Component {
     });
   }
 
-  downloadCSV() {
-    this.tabulator.download("csv", "data.csv");
+  downloadCSV(reportType) {
+    this.tabulator.download('csv', `foia-${reportType}.csv`);
   }
 
   render() {
     return (
       <div>
         <div ref={(ref) => { this.element = ref; }} />
-        <button onClick={this.downloadCSV}>Download CSV</button>
+        <button onClick={() => this.downloadCSV('[report-type]')}>Download CSV</button>
       </div>
     );
   }

--- a/js/components/foia_report_results_table.jsx
+++ b/js/components/foia_report_results_table.jsx
@@ -14,6 +14,8 @@ class FoiaReportResultsTable extends Component {
     this.tabulator = null;
     this.tableData = [];
     this.columns = [];
+
+    this.downloadCSV = this.downloadCSV.bind(this);
   }
 
   componentDidMount() {
@@ -37,8 +39,17 @@ class FoiaReportResultsTable extends Component {
     });
   }
 
+  downloadCSV() {
+    this.tabulator.download("csv", "data.csv");
+  }
+
   render() {
-    return (<div ref={(ref) => { this.element = ref; }} />);
+    return (
+      <div>
+        <div ref={(ref) => { this.element = ref; }} />
+        <button onClick={this.downloadCSV}>Download CSV</button>
+      </div>
+    );
   }
 }
 

--- a/js/components/foia_report_results_table.jsx
+++ b/js/components/foia_report_results_table.jsx
@@ -16,7 +16,13 @@ class FoiaReportResultsTable extends Component {
     this.columns = [];
 
     this.downloadCSV = this.downloadCSV.bind(this);
+
+    this.state = {
+      reportTable: false,
+    };
+
   }
+
 
   componentDidMount() {
     const sampleData = [
@@ -47,7 +53,6 @@ class FoiaReportResultsTable extends Component {
     return (
       <div>
         <div ref={(ref) => { this.element = ref; }} />
-        <button onClick={() => this.downloadCSV('[report-type]')}>Download CSV</button>
       </div>
     );
   }

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -21,10 +21,12 @@ class FoiaReportDataSubmit extends Component {
   }
 
   handleSubmit(event) {
-    event.preventDefault();
     reportActions.returnFieldValidationStateOnSubmit();
     if (this.formIsValid()) {
       reportActions.fetchAnnualReportData(this.props.selectedDataTypes);
+    }
+    else {
+      event.preventDefault();
     }
   }
 

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -32,7 +32,7 @@ class FoiaReportDataSubmit extends Component {
     event.preventDefault();
     reportActions.returnFieldValidationStateOnSubmit();
     if (this.formIsValid()) {
-      // print the CSV
+      this.props.onClick(event);
     }
   }
 
@@ -52,6 +52,7 @@ FoiaReportDataSubmit.propTypes = {
   fiscalYearsIsValid: PropTypes.bool.isRequired,
   dataTypesIsValid: PropTypes.bool.isRequired,
   agencyComponentIsValid: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
 };
 
 FoiaReportDataSubmit.defaultProps = {

--- a/js/pages/annual_report_data.jsx
+++ b/js/pages/annual_report_data.jsx
@@ -47,6 +47,7 @@ class AnnualReportDataPage extends Component {
       fiscalYearsDisplayError,
       dataTypeDisplayError,
       agencyComponentDisplayError,
+      tableDataTypes,
     } = annualReportDataFormStore.getState();
 
     const {
@@ -71,12 +72,21 @@ class AnnualReportDataPage extends Component {
       fiscalYearsDisplayError,
       dataTypeDisplayError,
       agencyComponentDisplayError,
+      tableDataTypes,
       selectedAgencies,
       dataTypes,
       dataTypeOptions,
       selectedDataTypes,
       reports,
     };
+  }
+
+  triggerCSV(event) {
+    event.preventDefault();
+
+    this.state.tableDataTypes.forEach((selectedDataType) => {
+      this.reportTable.downloadCSV(selectedDataType);
+    });
   }
 
   componentDidMount() {
@@ -140,9 +150,17 @@ class AnnualReportDataPage extends Component {
             agencyComponentIsValid={agencyComponentIsValid}
             dataTypesIsValid={dataTypesIsValid}
             fiscalYearsIsValid={fiscalYearsIsValid}
+            onClick={this.triggerCSV.bind(this)}
           />
         </form>
-        <FoiaReportResultsTable />
+
+        <div className="results-toolbar">
+          <button type="button" className="usa-button usa-button-big usa-button-primary-alt">Print</button>
+          <button onClick={this.triggerCSV.bind(this)} type="button" className="usa-button usa-button-big usa-button-primary-alt">Download CSV</button>
+        </div>
+        <FoiaReportResultsTable
+          ref={reportTable => this.reportTable = reportTable}
+        />
       </div>
     );
   }

--- a/js/stores/annual_report_data_form.js
+++ b/js/stores/annual_report_data_form.js
@@ -152,6 +152,28 @@ class AnnualReportDataFormStore extends Store {
         break;
       }
 
+      case types.GET_TABLE_DATA_TYPES: {
+        const { dataTypeOptions } = payload;
+        const tableDataTypes = [];
+        this.state.selectedDataTypes.forEach((selectedDataType) => {
+          if (selectedDataType.id.length > 0) {
+            const selectedID = selectedDataType.id;
+            dataTypeOptions.forEach((dataTypeOption) => {
+              const optionValue = dataTypeOption.value;
+              if (selectedID === optionValue) {
+                let tableDataType = dataTypeOption.label;
+                tableDataType = tableDataType.replace(/[^a-zA-Z ]/g, "").trim().replace(/[^A-Z0-9]+/ig, "-").toLowerCase();
+                tableDataTypes.push(tableDataType)
+              }
+            });
+          }
+        });
+
+        Object.assign(this.state, { tableDataTypes });
+        this.__emitChange();
+        break;
+      }
+
       case types.SELECTED_FISCAL_YEARS_UPDATE: {
         const { data } = payload;
         if (!Array.isArray(data)) {

--- a/www.foia.gov/_sass/_modules.scss
+++ b/www.foia.gov/_sass/_modules.scss
@@ -20,6 +20,7 @@
 @import 'modules/page_header';
 @import 'modules/react_jsonschema_form';
 @import 'modules/request_summary';
+@import 'modules/results_toolbar';
 @import 'modules/sidebar';
 @import 'modules/site_footer';
 @import 'modules/site_header';

--- a/www.foia.gov/_sass/modules/_results_toolbar.scss
+++ b/www.foia.gov/_sass/modules/_results_toolbar.scss
@@ -1,0 +1,6 @@
+.results-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  margin: $space-5x 0;
+}


### PR DESCRIPTION
This will have merge conflicts with [PR for FOIA-336](https://github.com/acquia-pso/foia.gov-enhancements/pull/53).

Adds CSV download method
Adds handling for `Download CSV` button on form page
Adds `Download CSV` button for results page
Creates filenames from selected data types