### PR TITLE
FOIA-354: Build api request with filters.

### DIFF
--- a/js/actions/report.js
+++ b/js/actions/report.js
@@ -225,14 +225,9 @@ export const reportActions = {
   },
 
   /**
-   * Get reports from the api, only including fields from the named sections.
+   * Makes a base report api request with the correct events dispatched
+   * while allowing the request to be modified before sending.
    *
-   * @param {List<string> | Array<string>} sections
-   *   A list of the section names to retrieve, which will be transformed into
-   *   a map of includes and fields on the jsonapi request.
-   * @param {Boolean} agencyOverall
-   *   A boolean to determine if the request should include the agency overall
-   *   fields if the section.
    * @param {Function | null} modifier
    *   An optional function that will get the JsonapiParams request object.
    *   This function allows modifications to the request such as adding filters
@@ -243,7 +238,7 @@ export const reportActions = {
    * @see js/stores/annual_report_data_types.js
    * @see www.foia.gov/api/annual-report-form/report_data_map.json
    */
-  fetchAnnualReportData(sections = List(), agencyOverall = true, modifier = null) {
+  fetchAnnualReportData(modifier = null) {
     dispatcher.dispatch({
       type: types.ANNUAL_REPORT_DATA_FETCH,
     });
@@ -252,7 +247,6 @@ export const reportActions = {
     // modifier function if it needs to be.
     let builder = new FoiaAnnualReportRequestBuilder();
     builder.request.limit(5);
-    builder = builder.includeSections(sections, agencyOverall);
 
     if (modifier && typeof modifier === 'function') {
       builder = modifier(builder);

--- a/js/actions/report.js
+++ b/js/actions/report.js
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import axios from 'axios';
 import settings from 'settings';
-import { List } from 'immutable';
 
 import dispatcher from '../util/dispatcher';
 import jsonapi from '../util/json_api';

--- a/js/actions/report.js
+++ b/js/actions/report.js
@@ -7,7 +7,7 @@ import dispatcher from '../util/dispatcher';
 import jsonapi from '../util/json_api';
 import localapi from '../util/local_api';
 import date from '../util/current_date';
-import reportRequestBuilder from '../util/foia_annual_report_request_builder';
+import { FoiaAnnualReportRequestBuilder } from '../util/foia_annual_report_request_builder';
 
 // Action types to identify an action
 export const types = {
@@ -250,7 +250,7 @@ export const reportActions = {
 
     // The default limit could be updated in the
     // modifier function if it needs to be.
-    let builder = reportRequestBuilder;
+    let builder = new FoiaAnnualReportRequestBuilder();
     builder.request.limit(5);
     builder = builder.includeSections(sections, agencyOverall);
 

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -51,15 +51,23 @@ class FoiaReportDataSubmit extends Component {
         return List.isList(overall) ? overall.size > 0 : overall.length > 0;
       }).length > 0;
 
+      let updatedBuilder = builder;
+      if (includeOverall) {
+        updatedBuilder = updatedBuilder.includeOverallFields(this.props.selectedDataTypes);
+      }
 
-      return builder
-        .includeDataTypes(this.props.selectedDataTypes, includeOverall)
+      if (!this.props.allAgenciesSelected) {
+        updatedBuilder = updatedBuilder
+          .includeDataTypes(this.props.selectedDataTypes)
+          .addOrganizationsGroup({
+            agencies: agencies.map(agency => agency.abbreviation),
+            components: components.map(component => component.abbreviation),
+          });
+      }
+
+      return updatedBuilder
         .addDataTypeFiltersGroup(dataTypeFilters)
-        .addFiscalYearsGroup(this.props.selectedFiscalYears)
-        .addOrganizationsGroup({
-          agencies: agencies.map(agency => agency.abbreviation),
-          components: components.map(component => component.abbreviation),
-        });
+        .addFiscalYearsGroup(this.props.selectedFiscalYears);
     });
   }
 

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -67,6 +67,7 @@ class FoiaReportDataSubmit extends Component {
 
 FoiaReportDataSubmit.propTypes = {
   selectedDataTypes: PropTypes.array,
+  selectedFiscalYears: PropTypes.array,
   fiscalYearsIsValid: PropTypes.bool.isRequired,
   dataTypesIsValid: PropTypes.bool.isRequired,
   agencyComponentIsValid: PropTypes.bool.isRequired,
@@ -74,6 +75,7 @@ FoiaReportDataSubmit.propTypes = {
 
 FoiaReportDataSubmit.defaultProps = {
   selectedDataTypes: [],
+  selectedFiscalYears: [],
 };
 
 export default FoiaReportDataSubmit;

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -45,7 +45,7 @@ class FoiaReportDataSubmit extends Component {
 
 
         return builder
-          .includeSections(this.props.selectedDataTypes, includeOverall)
+          .includeDataTypes(this.props.selectedDataTypes, includeOverall)
           .addFiscalYearsGroup(this.props.selectedFiscalYears)
           .addOrganizationsGroup({
             agencies: agencies.map(agency => agency.abbreviation),

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -46,6 +46,7 @@ class FoiaReportDataSubmit extends Component {
 
         return builder
           .includeSections(this.props.selectedDataTypes, includeOverall)
+          .addFiscalYearsGroup(this.props.selectedFiscalYears)
           .addOrganizationsGroup({
             agencies: agencies.map(agency => agency.abbreviation),
             components: components.map(component => component.abbreviation),

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -31,32 +31,36 @@ class FoiaReportDataSubmit extends Component {
         type: types.REPORT_SUBMISSION_TYPE,
         submissionAction: action,
       });
-      reportActions.fetchAnnualReportData((builder) => {
-        const selectedAgencies = annualReportDataFormStore.getSelectedAgencies();
-        const agencies = selectedAgencies.filter(selection => selection.type === 'agency');
-        const components = selectedAgencies.filter(selection => selection.type === 'agency_component');
-        const dataTypeFilters = this.props.selectedDataTypes
-          .filter(selection => selection.filter.applied || false)
-          .map(selection => selection.filter);
-        const includeOverall = agencies.filter((agency) => {
-          const overall = agency
-            .components
-            .filter(component => component.selected && component.isOverall);
-
-          return List.isList(overall) ? overall.size > 0 : overall.length > 0;
-        }).length > 0;
-
-
-        return builder
-          .includeDataTypes(this.props.selectedDataTypes, includeOverall)
-          .addDataTypeFiltersGroup(dataTypeFilters)
-          .addFiscalYearsGroup(this.props.selectedFiscalYears)
-          .addOrganizationsGroup({
-            agencies: agencies.map(agency => agency.abbreviation),
-            components: components.map(component => component.abbreviation),
-          });
-      });
+      this.makeApiRequests();
     }
+  }
+
+  makeApiRequests() {
+    reportActions.fetchAnnualReportData((builder) => {
+      const selectedAgencies = annualReportDataFormStore.getSelectedAgencies();
+      const agencies = selectedAgencies.filter(selection => selection.type === 'agency');
+      const components = selectedAgencies.filter(selection => selection.type === 'agency_component');
+      const dataTypeFilters = this.props.selectedDataTypes
+        .filter(selection => selection.filter.applied || false)
+        .map(selection => selection.filter);
+      const includeOverall = agencies.filter((agency) => {
+        const overall = agency
+          .components
+          .filter(component => component.selected && component.isOverall);
+
+        return List.isList(overall) ? overall.size > 0 : overall.length > 0;
+      }).length > 0;
+
+
+      return builder
+        .includeDataTypes(this.props.selectedDataTypes, includeOverall)
+        .addDataTypeFiltersGroup(dataTypeFilters)
+        .addFiscalYearsGroup(this.props.selectedFiscalYears)
+        .addOrganizationsGroup({
+          agencies: agencies.map(agency => agency.abbreviation),
+          components: components.map(component => component.abbreviation),
+        });
+    });
   }
 
   render() {

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -37,7 +37,7 @@ class FoiaReportDataSubmit extends Component {
 
   makeApiRequests() {
     reportActions.fetchAnnualReportData((builder) => {
-      const selectedAgencies = annualReportDataFormStore.getSelectedAgencies();
+      const selectedAgencies = annualReportDataFormStore.buildSelectedAgencies();
       const agencies = selectedAgencies.filter(selection => selection.type === 'agency');
       const components = selectedAgencies.filter(selection => selection.type === 'agency_component');
       const dataTypeFilters = this.props.selectedDataTypes

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -35,6 +35,9 @@ class FoiaReportDataSubmit extends Component {
         const selectedAgencies = annualReportDataFormStore.getSelectedAgencies();
         const agencies = selectedAgencies.filter(selection => selection.type === 'agency');
         const components = selectedAgencies.filter(selection => selection.type === 'agency_component');
+        const dataTypeFilters = this.props.selectedDataTypes
+          .filter(selection => selection.filter.applied || false)
+          .map(selection => selection.filter);
         const includeOverall = agencies.filter((agency) => {
           const overall = agency
             .components
@@ -46,6 +49,7 @@ class FoiaReportDataSubmit extends Component {
 
         return builder
           .includeDataTypes(this.props.selectedDataTypes, includeOverall)
+          .addDataTypeFiltersGroup(dataTypeFilters)
           .addFiscalYearsGroup(this.props.selectedFiscalYears)
           .addOrganizationsGroup({
             agencies: agencies.map(agency => agency.abbreviation),

--- a/js/components/foia_report_submit.jsx
+++ b/js/components/foia_report_submit.jsx
@@ -75,6 +75,7 @@ class FoiaReportDataSubmit extends Component {
 }
 
 FoiaReportDataSubmit.propTypes = {
+  allAgenciesSelected: PropTypes.bool,
   selectedDataTypes: PropTypes.array,
   selectedFiscalYears: PropTypes.array,
   fiscalYearsIsValid: PropTypes.bool.isRequired,
@@ -83,6 +84,7 @@ FoiaReportDataSubmit.propTypes = {
 };
 
 FoiaReportDataSubmit.defaultProps = {
+  allAgenciesSelected: false,
   selectedDataTypes: [],
   selectedFiscalYears: [],
 };

--- a/js/pages/annual_report_data.jsx
+++ b/js/pages/annual_report_data.jsx
@@ -166,6 +166,7 @@ return (
             />
             <FoiaReportDataSubmit
               selectedDataTypes={selectedDataTypes}
+              selectedFiscalYears={selectedFiscalYears}
               agencyComponentIsValid={agencyComponentIsValid}
               dataTypesIsValid={dataTypesIsValid}
               fiscalYearsIsValid={fiscalYearsIsValid}

--- a/js/pages/annual_report_data.jsx
+++ b/js/pages/annual_report_data.jsx
@@ -165,8 +165,6 @@ return (
               fiscalYearsDisplayError={fiscalYearsDisplayError}
             />
             <FoiaReportDataSubmit
-              allAgenciesSelected={allAgenciesSelected}
-              selectedAgencies={selectedAgencies}
               selectedDataTypes={selectedDataTypes}
               agencyComponentIsValid={agencyComponentIsValid}
               dataTypesIsValid={dataTypesIsValid}

--- a/js/pages/annual_report_data.jsx
+++ b/js/pages/annual_report_data.jsx
@@ -165,6 +165,7 @@ return (
               fiscalYearsDisplayError={fiscalYearsDisplayError}
             />
             <FoiaReportDataSubmit
+              allAgenciesSelected={allAgenciesSelected}
               selectedDataTypes={selectedDataTypes}
               selectedFiscalYears={selectedFiscalYears}
               agencyComponentIsValid={agencyComponentIsValid}

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -22,7 +22,12 @@ class AnnualReportStore extends Store {
   __onDispatch(payload) {
     switch (payload.type) {
       case types.ANNUAL_REPORT_DATA_FETCH: {
+        // Reset the report data to initial value so that report state after a new form submission
+        // is limited to only the data specific to that request.
         this.state.reportDataComplete = false;
+        Object.assign(this.state, {
+          reports: new Map(),
+        });
         this.__emitChange();
         break;
       }

--- a/js/stores/annual_report_data_form.js
+++ b/js/stores/annual_report_data_form.js
@@ -28,7 +28,7 @@ class AnnualReportDataFormStore extends Store {
     return this.state;
   }
 
-  getSelectedAgencies() {
+  buildSelectedAgencies() {
     if (!this.state.allAgenciesSelected) {
       return [...this.state.selectedAgencies];
     }
@@ -37,7 +37,7 @@ class AnnualReportDataFormStore extends Store {
     // where the only component is an overall component.
     let { agencies } = agencyComponentStore.getState();
     agencies = agencies.map(agency => (
-      Object.assign({}, agency, {
+      Object.assign({}, agency.toJS(), {
         components: List([{
           abbreviation: 'Agency Overall',
           id: `overall:${agency.id}`,

--- a/js/stores/annual_report_data_form.js
+++ b/js/stores/annual_report_data_form.js
@@ -158,7 +158,7 @@ class AnnualReportDataFormStore extends Store {
             .fields
             .filter(opt => opt.filter)
             .map(opt => ({
-              value: opt.id,
+              value: opt.filter === true ? opt.id : opt.filter,
               label: opt.label,
             }));
           // Add a default filter definition to make removing a submitted filter

--- a/js/test/util/foia_report_request_builder.test.js
+++ b/js/test/util/foia_report_request_builder.test.js
@@ -370,10 +370,10 @@ describe('FoiaAnnualReportRequestBuilder', () => {
     });
   });
 
-  describe('::includeSections', () => {
+  describe('::includeDataTypes', () => {
     it('builds includes and fields based on sections defined in the annualReportDataTypesStore', () => {
       const { selectedDataTypes } = annualReportDataFormStore.getState();
-      requestBuilder.includeSections(selectedDataTypes, false);
+      requestBuilder.includeDataTypes(selectedDataTypes, false);
 
       expect(requestBuilder.request._params, '_params').to.have.property('include');
       expect(requestBuilder.request._params.include.sort(), 'requestBuilder.request._params.include')

--- a/js/test/util/foia_report_request_builder.test.js
+++ b/js/test/util/foia_report_request_builder.test.js
@@ -370,6 +370,73 @@ describe('FoiaAnnualReportRequestBuilder', () => {
     });
   });
 
+  describe('::addDataTypeFiltersGroup', () => {
+    it('adds data type filters when given an array of filter objects', () => {
+      requestBuilder.addDataTypeFiltersGroup([
+        {
+          filterField: 'field_admin_app_via.field_app_pend_start_yr',
+          op: 'greater_than',
+          compareValue: '4',
+        },
+        {
+          filterField: 'field_foia_requests_vb1.field_full_grants',
+          op: 'equal_to',
+          compareValue: '6',
+        },
+        {
+          filterField: 'field_proc_req_viia.field_comp_high',
+          op: 'is_na',
+        },
+        {
+          filterField: 'field_req_viiia.field_num_jud_w10',
+          op: 'less_than',
+          compareValue: '20',
+        },
+      ]);
+
+      expect(requestBuilder.request._params).to.have.property('filter');
+      expect(requestBuilder.request._params.filter).to.deep.equal({
+        'data-type-filter-0': {
+          condition: {
+            memberOf: 'or-filter-1',
+            operator: '>',
+            path: 'field_admin_app_via.field_app_pend_start_yr',
+            value: '4',
+          },
+        },
+        'data-type-filter-1': {
+          condition: {
+            memberOf: 'or-filter-1',
+            operator: '=',
+            path: 'field_foia_requests_vb1.field_full_grants',
+            value: '6',
+          },
+        },
+        'data-type-filter-2': {
+          condition: {
+            memberOf: 'or-filter-1',
+            operator: '=',
+            path: 'field_proc_req_viia.field_comp_high',
+            value: 'N/A',
+          },
+        },
+        'data-type-filter-3': {
+          condition: {
+            memberOf: 'or-filter-1',
+            operator: '<',
+            path: 'field_req_viiia.field_num_jud_w10',
+            value: '20',
+          },
+        },
+        'or-filter-1': {
+          group: {
+            conjunction: 'OR',
+          },
+        },
+      });
+    });
+  });
+
   describe('::includeDataTypes', () => {
     it('builds includes and fields based on sections defined in the annualReportDataTypesStore', () => {
       const { selectedDataTypes } = annualReportDataFormStore.getState();

--- a/js/util/foia_annual_report_request_builder.js
+++ b/js/util/foia_annual_report_request_builder.js
@@ -91,16 +91,16 @@ class FoiaAnnualReportRequestBuilder extends JsonApi {
   /**
    * Include sections and their fields in the request.
    *
-   * @param {array | List } sections
-   *   An array of section group ids that can be retrieved from
+   * @param {array | List } types
+   *   An array of data type group ids that can be retrieved from
    *   the annualReportDataTypesStore.
    * @param {boolean} withOverallData
    *   A boolean indicating whether or not to include agency overall fields in the request.
    * @returns {FoiaAnnualReportRequestBuilder}
    */
-  includeSections(sections, withOverallData = true) {
-    const dataTypes = Array.isArray(sections) || List.isList(sections)
-      ? List(sections)
+  includeDataTypes(types, withOverallData = true) {
+    const dataTypes = Array.isArray(types) || List.isList(types)
+      ? List(types)
       : List([]);
 
     const includes = FoiaAnnualReportRequestBuilder.getSectionIncludes(dataTypes);

--- a/www.foia.gov/api/annual-report-form/report_data_map.json
+++ b/www.foia.gov/api/annual-report-form/report_data_map.json
@@ -216,21 +216,21 @@
       {
         "id": "field_req_viiia.field_med_days_jud",
         "label": "Median Number of Days to Adjudicate",
-        "filter": true,
+        "filter": "field_req_viiia.field_med_days_jud.value",
         "overall_field": "field_overall_viiia_med_days_jud",
         "display": true
       },
       {
         "id": "field_req_viiia.field_avg_days_jud",
         "label": "Average Number of Days to Adjudicate",
-        "filter": true,
+        "filter": "field_req_viiia.field_avg_days_jud.value",
         "overall_field": "field_overall_viiia_avg_days_jud",
         "display": true
       },
       {
         "id": "field_req_viiia.field_num_jud_w10",
         "label": "Number Adjudicated Within Ten Calendar Days",
-        "filter": true,
+        "filter": "field_req_viiia.field_num_jud_w10.value",
         "overall_field": "field_overall_viiia_num_jud_w10",
         "display": true
       },
@@ -768,28 +768,28 @@
       {
         "id": "field_admin_app_vic4.field_med_num_days",
         "label": "Median Number of Days",
-        "filter": true,
+        "filter": "field_admin_app_vic4.field_med_num_days.value",
         "overall_field": "field_overall_vic4_med_num_days",
         "display": true
       },
       {
         "id": "field_admin_app_vic4.field_avg_num_days",
         "label": "Average Number of Days",
-        "filter": true,
+        "filter": "field_admin_app_vic4.field_avg_num_days.value",
         "overall_field": "field_overall_vic4_avg_num_days",
         "display": true
       },
       {
         "id": "field_admin_app_vic4.field_low_num_days",
         "label": "Lowest Number of Days",
-        "filter": true,
+        "filter": "field_admin_app_vic4.field_low_num_days.value",
         "overall_field": "field_overall_vic4_low_num_days",
         "display": true
       },
       {
         "id": "field_admin_app_vic4.field_high_num_days",
         "label": "Highest Number of Days",
-        "filter": true,
+        "filter": "field_admin_app_vic4.field_high_num_days.value",
         "overall_field": "field_overall_vic4_high_num_days",
         "display": true
       },
@@ -821,7 +821,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_10",
         "label": "10th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_10.value",
         "overall_field": "field_overall_vic5_num_day_10",
         "display": true
       },
@@ -835,7 +835,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_9",
         "label": "9th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_9.value",
         "overall_field": "field_overall_vic5_num_day_9",
         "display": true
       },
@@ -849,7 +849,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_8",
         "label": "8th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_8.value",
         "overall_field": "field_overall_vic5_num_day_8",
         "display": true
       },
@@ -863,7 +863,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_7",
         "label": "7th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_7.value",
         "overall_field": "field_overall_vic5_num_day_7",
         "display": true
       },
@@ -877,7 +877,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_6",
         "label": "6th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_6.value",
         "overall_field": "field_overall_vic5_num_day_6",
         "display": true
       },
@@ -891,7 +891,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_5",
         "label": "5th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_5.value",
         "overall_field": "field_overall_vic5_num_day_5",
         "display": true
       },
@@ -905,7 +905,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_4",
         "label": "4th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_4.value",
         "overall_field": "field_overall_vic5_num_day_4",
         "display": true
       },
@@ -919,7 +919,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_3",
         "label": "3rd Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_3.value",
         "overall_field": "field_overall_vic5_num_day_3",
         "display": true
       },
@@ -933,7 +933,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_2",
         "label": "2nd Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_2.value",
         "overall_field": "field_overall_vic5_num_day_2",
         "display": true
       },
@@ -947,7 +947,7 @@
       {
         "id": "field_admin_app_vic5.field_num_days_1",
         "label": "Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_vic5.field_num_days_1.value",
         "overall_field": "field_overall_vic5_num_day_1",
         "display": true
       },
@@ -972,84 +972,84 @@
       {
         "id": "field_proc_req_viia.field_sim_med",
         "label": "Simple - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_sim_med.value",
         "overall_field": "field_overall_viia_sim_med",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_sim_avg",
         "label": "Simple - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_sim_avg.value",
         "overall_field": "field_overall_viia_sim_avg",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_sim_low",
         "label": "Simple - Lowest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_sim_low.value",
         "overall_field": "field_overall_viia_sim_low",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_sim_high",
         "label": "Simple - Highest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_sim_high.value",
         "overall_field": "field_overall_viia_sim_high",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_comp_med",
         "label": "Complex - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_comp_med.value",
         "overall_field": "field_overall_viia_comp_med",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_comp_avg",
         "label": "Complex - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_comp_avg.value",
         "overall_field": "field_overall_viia_comp_avg",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_comp_low",
         "label": "Complex - Lowest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_comp_low.value",
         "overall_field": "field_overall_viia_comp_low",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_comp_high",
         "label": "Complex - Highest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_comp_high.value",
         "overall_field": "field_overall_viia_comp_high",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_exp_med",
         "label": "Expedited Processing - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_exp_med.value",
         "overall_field": "field_overall_viia_exp_med",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_exp_avg",
         "label": "Expedited Processing - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_exp_avg.value",
         "overall_field": "field_overall_viia_exp_avg",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_exp_low",
         "label": "Expedited Processing - Lowest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_exp_low.value",
         "overall_field": "field_overall_viia_exp_low",
         "display": true
       },
       {
         "id": "field_proc_req_viia.field_exp_high",
         "label": "Expedited Processing - Highest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viia.field_exp_high.value",
         "overall_field": "field_overall_viia_exp_high",
         "display": true
       },
@@ -1074,84 +1074,84 @@
       {
         "id": "field_proc_req_viib.field_sim_med",
         "label": "Simple - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_sim_med.value",
         "overall_field": "field_overall_viib_sim_med",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_sim_avg",
         "label": "Simple - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_sim_avg.value",
         "overall_field": "field_overall_viib_sim_avg",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_sim_low",
         "label": "Simple - Lowest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_sim_low.value",
         "overall_field": "field_overall_viib_sim_low",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_sim_high",
         "label": "Simple - Highest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_sim_high.value",
         "overall_field": "field_overall_viib_sim_high",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_comp_med",
         "label": "Complex - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_comp_med.value",
         "overall_field": "field_overall_viib_comp_med",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_comp_avg",
         "label": "Complex - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_comp_avg.value",
         "overall_field": "field_overall_viib_comp_avg",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_comp_low",
         "label": "Complex - Lowest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_comp_low.value",
         "overall_field": "field_overall_viib_comp_low",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_comp_high",
         "label": "Complex - Highest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_comp_high.value",
         "overall_field": "field_overall_viib_comp_high",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_exp_med",
         "label": "Expedited Processing - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_exp_med.value",
         "overall_field": "field_overall_viib_exp_med",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_exp_avg",
         "label": "Expedited Processing - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_exp_avg.value",
         "overall_field": "field_overall_viib_exp_avg",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_exp_low",
         "label": "Expedited Processing - Lowest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_exp_low.value",
         "overall_field": "field_overall_viib_exp_low",
         "display": true
       },
       {
         "id": "field_proc_req_viib.field_exp_high",
         "label": "Expedited Processing - Highest Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_viib.field_exp_high.value",
         "overall_field": "field_overall_viib_exp_high",
         "display": true
       },
@@ -1524,63 +1524,63 @@
       {
         "id": "field_pending_requests_vii_d_.field_sim_pend",
         "label": "Simple - Number Pending",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_sim_pend.value",
         "overall_field": "field_overall_viid_sim_pend",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_sim_med",
         "label": "Simple - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_sim_med.value",
         "overall_field": "field_overall_viid_sim_med",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_sim_avg",
         "label": "Simple - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_sim_avg.value",
         "overall_field": "field_overall_viid_sim_avg",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_comp_pend",
         "label": "Complex - Number Pending",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_comp_pend.value",
         "overall_field": "field_overall_viid_comp_pend",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_comp_med",
         "label": "Complex - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_comp_med.value",
         "overall_field": "field_overall_viid_comp_med",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_comp_avg",
         "label": "Complex - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_comp_avg.value",
         "overall_field": "field_overall_viid_comp_avg",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_exp_pend",
         "label": "Expedited Processing - Number Pending",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_exp_pend.value",
         "overall_field": "field_overall_viid_exp_pend",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_exp_med",
         "label": "Expedited Processing - Median Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_exp_med.value",
         "overall_field": "field_overall_viid_exp_med",
         "display": true
       },
       {
         "id": "field_pending_requests_vii_d_.field_exp_avg",
         "label": "Expedited Processing - Average Number of Days",
-        "filter": true,
+        "filter": "field_proc_req_vii_d_.field_exp_avg.value",
         "overall_field": "field_overall_viid_exp_avg",
         "display": true
       },
@@ -1612,7 +1612,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_10",
         "label": "10th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_10.value",
         "overall_field": "field_overall_viie_num_days_10",
         "display": true
       },
@@ -1626,7 +1626,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_9",
         "label": "9th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_9.value",
         "overall_field": "field_overall_viie_num_days_9",
         "display": true
       },
@@ -1640,7 +1640,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_8",
         "label": "8th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_8.value",
         "overall_field": "field_overall_viie_num_days_8",
         "display": true
       },
@@ -1654,7 +1654,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_7",
         "label": "7th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_7.value",
         "overall_field": "field_overall_viie_num_days_7",
         "display": true
       },
@@ -1668,7 +1668,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_6",
         "label": "6th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_6.value",
         "overall_field": "field_overall_viie_num_days_6",
         "display": true
       },
@@ -1682,7 +1682,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_5",
         "label": "5th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_5.value",
         "overall_field": "field_overall_viie_num_days_5",
         "display": true
       },
@@ -1696,7 +1696,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_4",
         "label": "4th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_4.value",
         "overall_field": "field_overall_viie_num_days_4",
         "display": true
       },
@@ -1710,7 +1710,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_3",
         "label": "3rd Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_3.value",
         "overall_field": "field_overall_viie_num_days_3",
         "display": true
       },
@@ -1724,7 +1724,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_2",
         "label": "2nd Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_2.value",
         "overall_field": "field_overall_viie_num_days_2",
         "display": true
       },
@@ -1738,7 +1738,7 @@
       {
         "id": "field_admin_app_viie.field_num_days_1",
         "label": "Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_admin_app_viie.field_num_days_1.value",
         "overall_field": "field_overall_viie_num_days_1",
         "display": true
       },
@@ -1777,14 +1777,14 @@
       {
         "id": "field_req_viiib.field_med_days_jud",
         "label": "Median Number of Days to Adjudicate",
-        "filter": true,
+        "filter": "field_req_viiib.field_med_days_jud.value",
         "overall_field": "field_overall_viiib_med_days_jud",
         "display": true
       },
       {
         "id": "field_req_viiib.field_avg_days_jud",
         "label": "Average Number of Days to Adjudicate",
-        "filter": true,
+        "filter": "field_req_viiib.field_avg_days_jud.value",
         "overall_field": "field_overall_viiib_avg_days_jud",
         "display": true
       },
@@ -1974,7 +1974,7 @@
       {
         "id": "field_foia_xiia.field_back_app_end_yr",
         "label": "Number of Backlogged Appeals as of End of Fiscal Year",
-        "filter": true,
+        "filter": "field_foia_xiia.field_back_app_end_yr.value",
         "overall_field": "field_overall_xiia_back_app_end_",
         "display": true
       },
@@ -2052,7 +2052,7 @@
       {
         "id": "field_foia_xiic.field_num_days_10",
         "label": "10th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_10.value",
         "overall_field": "field_overall_xiic_num_days_10",
         "display": true
       },
@@ -2066,7 +2066,7 @@
       {
         "id": "field_foia_xiic.field_num_days_9",
         "label": "9th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_9.value",
         "overall_field": "field_overall_xiic_num_days_9",
         "display": true
       },
@@ -2080,7 +2080,7 @@
       {
         "id": "field_foia_xiic.field_num_days_8",
         "label": "8th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_8.value",
         "overall_field": "field_overall_xiic_num_days_8",
         "display": true
       },
@@ -2094,7 +2094,7 @@
       {
         "id": "field_foia_xiic.field_num_days_7",
         "label": "7th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_7.value",
         "overall_field": "field_overall_xiic_num_days_7",
         "display": true
       },
@@ -2108,7 +2108,7 @@
       {
         "id": "field_foia_xiic.field_num_days_6",
         "label": "6th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_6.value",
         "overall_field": "field_overall_xiic_num_days_6",
         "display": true
       },
@@ -2122,7 +2122,7 @@
       {
         "id": "field_foia_xiic.field_num_days_5",
         "label": "5th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_5.value",
         "overall_field": "field_overall_xiic_num_days_5",
         "display": true
       },
@@ -2136,7 +2136,7 @@
       {
         "id": "field_foia_xiic.field_num_days_4",
         "label": "4th Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_4.value",
         "overall_field": "field_overall_xiic_num_days_4",
         "display": true
       },
@@ -2150,7 +2150,7 @@
       {
         "id": "field_foia_xiic.field_num_days_3",
         "label": "3rd Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_3.value",
         "overall_field": "field_overall_xiic_num_days_3",
         "display": true
       },
@@ -2164,7 +2164,7 @@
       {
         "id": "field_foia_xiic.field_num_days_2",
         "label": "2nd Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_2.value",
         "overall_field": "field_overall_xiic_num_days_2",
         "display": true
       },
@@ -2178,7 +2178,7 @@
       {
         "id": "field_foia_xiic.field_num_days_1",
         "label": "Oldest Number of Days Pending",
-        "filter": true,
+        "filter": "field_foia_xiic.field_num_days_1.value",
         "overall_field": "field_overall_xiic_num_days_1",
         "display": true
       },


### PR DESCRIPTION
* Builds api requests in the `FoiaReportDataSubmit` based on the form's
applied filters.
* Updates the request builder based on new requirements for data type filters
and including only overall fields in some instances.
* Fixes the request builder singleton being used and old filters applied 
if submit is hit multiple times.

Requires: 
  * https://github.com/acquia-pso/foia-api-enhancements/pull/348 - filtering by data type fields will not until this is merged to the backend.