### PR TITLE
FOIA-320: Build component data rows.

### DIFF
--- a/docs/annual-report-data-app.md
+++ b/docs/annual-report-data-app.md
@@ -254,7 +254,7 @@ Example use:
 
 ### Utilities
 
-### FoiaAnnualReportUtilities
+#### FoiaAnnualReportUtilities
 
 A utility class with static methods that can be used to get an
 array of data objects, suitable to be passed to tabulator,

--- a/docs/annual-report-data-app.md
+++ b/docs/annual-report-data-app.md
@@ -250,3 +250,20 @@ Example use:
   displayMode={submissionAction}
 />
 ```
+
+
+### Utilities
+
+### FoiaAnnualReportUtilities
+
+A utility class with static methods that can be used to get an
+array of data objects, suitable to be passed to tabulator,
+from a report that include the data specified by the included
+fields in the report_data_map.json file.
+
+Example use:
+```
+import FoiaAnnualReportUtilities from 'utils/foia_annual_report_utilities';
+...
+const rows = FoiaAnnualReportUtilities.getDataForType(report, dataType);
+```

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -22,8 +22,6 @@ class AnnualReportStore extends Store {
 
 
   static getSelectedAgencies() {
-    // @todo: This method returns agency/component abbreviations, but we may
-    // want to return uuids instead.
     const { selectedAgencies } = annualReportDataFormStore.getState();
     return selectedAgencies.reduce((formatted, selected) => {
       switch (selected.type) {
@@ -58,9 +56,7 @@ class AnnualReportStore extends Store {
   }
 
   getReportDataForType(dataType) {
-    // @todo: Confirm: Any need to filter invalid fiscal years here? Any need to
-    // filter data based on any other report filters here? Assuming not...
-
+    // @todo: Filter rows based on data type filters.
     const tableData = [];
     const { reports } = this.state;
     const selectedAgencies = AnnualReportStore.getSelectedAgencies();

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -23,10 +23,6 @@ class AnnualReportStore extends Store {
   static getSelectedAgencies() {
     // @todo: This method returns agency/component abbreviations, but we may
     // want to return uuids instead.
-    // @todo: remove test values.
-    // const formatted = {
-    //   DOJ: ['OJP', 'ATF', 'FALSEY', 'Agency Overall'],
-    // };
     const { selectedAgencies } = annualReportDataFormStore.getState();
     return selectedAgencies.reduce((formatted, selected) => {
       switch (selected.type) {

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -19,6 +19,97 @@ class AnnualReportStore extends Store {
     return this.state;
   }
 
+
+  static getSelectedAgencies() {
+    // @todo: This method returns agency/component abbreviations, but we may
+    // want to return uuids instead.
+    // @todo: remove test values.
+    const formatted = {
+      DOJ: ['OJP', 'ATF', 'FALSEY', 'Agency Overall'],
+    };
+    const { selectedAgencies } = annualReportDataFormStore.getState();
+    selectedAgencies.forEach((agency) => {
+      switch (agency.type) {
+        case 'agency': {
+          const { abbreviation } = agency;
+          // @todo: use a list, or be sure not to wipe out existing values...
+          // formatted[abbreviation] = ['Agency Overall'];
+          break;
+        }
+
+        case 'agency_component': {
+          // @todo: this...
+          break;
+        }
+
+        default:
+          break;
+      }
+    });
+    return formatted;
+  }
+
+  getReportDataForType(dataType) {
+    // @todo: Confirm: Any need to filter invalid fiscal years here? Any need to
+    // filter data based on any other report filters here? Assuming not...
+
+    const tableData = [];
+    const { reports } = this.state;
+    const selectedAgencies = AnnualReportStore.getSelectedAgencies();
+
+    // Iterate over each report.
+    reports.forEach((report) => {
+      const { abbreviation: agency_abbr, name: agency_name } = report.get('field_agency');
+      const selectedComponents = [...selectedAgencies[agency_abbr] || []];
+
+      // @todo: may want to refactor part of the loop so that it's run only once
+      // for the ANNUAL_REPORT_DATA_COMPLETE event instead of for each dataType.
+      const components = report.get('field_agency_components')
+        .map(component => component.abbreviation)
+        // Filter out components we haven't selected.
+        .filter((component) => {
+          return Object.keys(selectedAgencies).includes(agency_abbr)
+            && selectedAgencies[agency_abbr].includes(component);
+        })
+        // Since "Agency Overall" is not represented as a component attached to
+        // the report, manually add it to the end of the array when applicable.
+        .concat(selectedComponents.filter(component => component === 'Agency Overall'));
+
+      components.forEach((component) => {
+        let row = {};
+        // Iterate over fields defined for the dataType.
+        dataType.fields.forEach((field) => {
+          const { id, overall_field } = field;
+          const fiscal_year = report.get('field_foia_annual_report_yr');
+
+          row = Object.assign(row, {
+            component,
+            agency: agency_name,
+            fiscal_year,
+            // @todo: Confirm: Any requirements on how this string is formed / formatted?
+            id: `${agency_abbr}__${component}__${fiscal_year}`.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase(),
+          });
+
+          // Handle agency overall fields.
+          if (component.toLowerCase() === 'agency overall') {
+            // @todo: Any specific formatting requirements to consider here for each field value?
+            row[id] = report.get(overall_field);
+            return;
+          }
+
+          // @todo: handle all other fields in FOIA-320.
+          const parts = id.split('.');
+          row[id] = `Implementation pending for ${parts.join(' --> ')}`;
+        });
+
+        // Push the completed row.
+        tableData.push(row);
+      });
+    });
+
+    return tableData;
+  }
+
   __onDispatch(payload) {
     switch (payload.type) {
       case types.ANNUAL_REPORT_DATA_FETCH: {

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -183,8 +183,7 @@ class AnnualReportStore extends Store {
                   align: 'center',
                 }));
             const reportHeaders = defaultColumns.concat(dataColumns);
-            // @TODO: Actually fetch the data from the JSON:API result.
-            const dataRows = [];
+            const dataRows = this.getReportDataForType(dataType);
             tables.push({
               id: dataType.id,
               header: dataType.heading,

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -24,29 +24,40 @@ class AnnualReportStore extends Store {
     // @todo: This method returns agency/component abbreviations, but we may
     // want to return uuids instead.
     // @todo: remove test values.
-    const formatted = {
-      DOJ: ['OJP', 'ATF', 'FALSEY', 'Agency Overall'],
-    };
+    // const formatted = {
+    //   DOJ: ['OJP', 'ATF', 'FALSEY', 'Agency Overall'],
+    // };
     const { selectedAgencies } = annualReportDataFormStore.getState();
-    selectedAgencies.forEach((agency) => {
-      switch (agency.type) {
+    return selectedAgencies.reduce((formatted, selected) => {
+      switch (selected.type) {
         case 'agency': {
-          const { abbreviation } = agency;
-          // @todo: use a list, or be sure not to wipe out existing values...
-          // formatted[abbreviation] = ['Agency Overall'];
+          const { abbreviation, components } = selected;
+          const selectedComponents = formatted[abbreviation] || [];
+          const componentAbbreviations = components
+            .filter(component => component.selected)
+            .map(component => component.abbreviation);
+
+          formatted[abbreviation] = selectedComponents.concat(...componentAbbreviations.toArray())
+            .filter((value, index, array) => array.indexOf(value) === index)
+            .sort();
           break;
         }
-
         case 'agency_component': {
-          // @todo: this...
+          const { abbreviation, agency } = selected;
+          const agencyComponents = formatted[agency.abbreviation] || [];
+          formatted[agency.abbreviation] = agencyComponents
+            .concat(abbreviation)
+            .filter((value, index, array) => array.indexOf(value) === index)
+            .sort();
           break;
         }
-
-        default:
+        default: {
           break;
+        }
       }
-    });
-    return formatted;
+
+      return formatted;
+    }, {});
   }
 
   getReportDataForType(dataType) {

--- a/js/util/foia_annual_report_utilities.js
+++ b/js/util/foia_annual_report_utilities.js
@@ -256,7 +256,7 @@ class FoiaAnnualReportUtilities {
    */
   static flatten(raw = {}, field) {
     const data = raw[field] || false;
-    if (data === false) {
+    if (data === false || !Array.isArray(data) || data.length <= 0) {
       return [raw];
     }
 

--- a/js/util/foia_annual_report_utilities.js
+++ b/js/util/foia_annual_report_utilities.js
@@ -32,6 +32,15 @@ class FoiaAnnualReportUtilities {
    *   ]
    */
   static getDataForType(report, dataType) {
+    // By default, data can safely merge fields into an object keyed
+    // by component abbreviation.  This will, if required by the data type,
+    // zip data from multiple report fields into a single object
+    // based on the component abbreviation.
+    // The data types below that don't follow the default convention have
+    // nested data that, when flattened out,can result in multiple rows
+    // per component.  These must be merged on a unique identifying key
+    // that is not the component abbreviation so that multiple rows per
+    // component don't overwrite and merge together in unexpected ways.
     if (dataType.id === 'group_vi_c_3_reasons_for_denial_') {
       return FoiaAnnualReportUtilities.mergeBy(
         report,

--- a/js/util/foia_annual_report_utilities.js
+++ b/js/util/foia_annual_report_utilities.js
@@ -37,7 +37,7 @@ class FoiaAnnualReportUtilities {
     // zip data from multiple report fields into a single object
     // based on the component abbreviation.
     // The data types below that don't follow the default convention have
-    // nested data that, when flattened out,can result in multiple rows
+    // nested data that, when flattened out, can result in multiple rows
     // per component.  These must be merged on a unique identifying key
     // that is not the component abbreviation so that multiple rows per
     // component don't overwrite and merge together in unexpected ways.

--- a/js/util/foia_annual_report_utilities.js
+++ b/js/util/foia_annual_report_utilities.js
@@ -1,0 +1,301 @@
+import annualReportDataTypesStore from '../stores/annual_report_data_types';
+
+/**
+ * Utility functions for working with report data.
+ */
+class FoiaAnnualReportUtilities {
+  /**
+   * Given a report and data type, flattens out and merges the data into an array of
+   * objects that can be used by tabulator.
+   *
+   * @param {Map} report
+   *   A report retrieved from the api.
+   * @param {Object} dataType
+   *   A dataType object as defined in report_data_map.json.
+   * @returns {{}}
+   *   An array of objects where drupal paragraph data has been flattened for use by tabulator.
+   *   Example:
+   *   [
+   *     {
+   *       field_agency_component: 'BIS',
+   *       field_statute_iv: {
+   *         field_case_citation: "Sussman v. USMS, 494 F.3d",
+   *         field_statute: "Some statute name",
+   *         field_total_num_relied_by_agency: 30
+   *         field_type_of_info_withheld: "Type of info",
+   *         field_agency_component_inf: {
+   *           field_num_relied_by_agency_comp: 4,
+   *         }
+   *       }
+   *     }
+   *     ...
+   *   ]
+   */
+  static getDataForType(report, dataType) {
+    if (dataType.id === 'group_vi_c_3_reasons_for_denial_') {
+      return FoiaAnnualReportUtilities.mergeBy(
+        report,
+        dataType,
+        'field_admin_app_vic3.field_admin_app_vic3_info.field_desc_oth_reasons.value',
+      );
+    }
+
+    if (dataType.id === 'group_v_b_2_disposition_of_foia_') {
+      return FoiaAnnualReportUtilities.mergeBy(
+        report,
+        dataType,
+        'field_foia_requests_vb2.field_foia_req_vb2_info.field_desc_oth_reasons.value',
+      );
+    }
+
+    if (dataType.id === 'group_iv_exemption_3_statutes') {
+      return FoiaAnnualReportUtilities.mergeBy(
+        report,
+        dataType,
+        'field_statute_iv.field_statute',
+      );
+    }
+
+    return FoiaAnnualReportUtilities.mergeBy(report, dataType, 'field_agency_component');
+  }
+
+  /**
+   * Flattens any field data required by the data type, then merges field data that shares
+   * a unique identifier.
+   *
+   * @param {Map} report
+   *   A report retrieved from the api.
+   * @param {Object} dataType
+   *   A dataType object as defined in report_data_map.json.
+   * @param {string} idPath
+   *   A path to a unique field that can be used as an identifier, in dot notation.
+   * @returns {{}}
+   *   An array of objects where drupal paragraph data has been flattened for use by tabulator.
+   *   See the example return value for FoiaAnnualReportUtilities.getDataByType().
+   */
+  static mergeBy(report, dataType, idPath) {
+    const data = FoiaAnnualReportUtilities.flattenFields(report, dataType);
+    // Zips into an array where values that share the same unique id based
+    // on the idPath are merged into the same object.
+    return Object.keys(data).reduce((zipped, key) => {
+      const values = data[key] || [];
+      values.forEach((value) => {
+        const id = FoiaAnnualReportUtilities.buildRowId(idPath, value);
+        if (id === false) {
+          return;
+        }
+
+        const component = zipped[id] || {};
+        zipped[id] = Object.assign(component, value);
+      });
+
+      return zipped;
+    }, {});
+  }
+
+  /**
+   * Flattens any field included by a data type.
+   *
+   * Most cases will include data from a single field and only need to lift
+   * the component abbreviation to each data object in a field.  There are edge cases
+   * that contain nested arrays.  In these cases the top level data has to be merged
+   * into every nested object, creating a row for each nested array item.
+   *
+   * @param {Map} report
+   *   A report retrieved from the api.
+   * @param {Object} dataType
+   *   A dataType object as defined in report_data_map.json.
+   * @returns {Object}
+   *   An object containing the flattened values for each top level include of the
+   *   data type.
+   * @see report_data_map.json
+   */
+  static flattenFields(report, dataType) {
+    // Only deal with the includes that are report field.
+    // Nested data will be flattened later.
+    const fields = annualReportDataTypesStore.getIncludesForDataType(dataType.id)
+      .filter(field => field.split('.').length === 1);
+
+    return fields.reduce((values, field) => {
+      // Check for nested values that can be flattened and build an array
+      // of field objects.  If there are no nested values to flatten, the
+      // data variable will be equivalent to report.get(field).
+      const data = report.get(field).reduce((flattened, fieldValue) => (
+        flattened.concat(...FoiaAnnualReportUtilities.maybeFlatten(fieldValue))
+      ), []);
+
+      // Lift the component value up to each data object since tabulator will
+      // expect a field_agency_component field directly on each row.
+      const transformed = FoiaAnnualReportUtilities.mergeComponent(
+        data,
+        field,
+      );
+      const allTransformed = values[field] || [];
+      allTransformed.push(...transformed);
+      values[field] = allTransformed;
+
+      return values;
+    }, {});
+  }
+
+  /**
+   * Lift the component abbreviation up to sit directly on a data object.
+   *
+   * @param {Array} data
+   *   An array of component data objects.
+   * @param {string} parent
+   *   This data's parent field.
+   * @returns {*[]|*}
+   */
+  static mergeComponent(data = [], parent) {
+    if (!Array.isArray(data)) {
+      return data;
+    }
+
+    return data.reduce((collected, value) => {
+      const component = FoiaAnnualReportUtilities.retrieveComponent(value);
+      if (!component) {
+        return collected;
+      }
+      const compiled = {};
+      compiled[parent] = value;
+      compiled.field_agency_component = component;
+
+      return collected.concat(compiled);
+    }, []);
+  }
+
+  /**
+   * Retrieve a component abbreviation from the data objects that
+   * will be encountered once component data has been flattened.
+   *
+   * @param {Object} raw
+   *   A component data object.
+   * @returns {string|boolean}
+   *   The component abbreviation or false.
+   */
+  static retrieveComponent(raw) {
+    let value = raw;
+    // In most successful cases, the data passed to this method is an object that contains,
+    // a field_agency_component.abbreviation value. Statute data nests the field_agency_component
+    // within a field_agency_component_inf object, so lift the agency component information
+    // from there before continuing.
+    if (Object.prototype.hasOwnProperty.call(value, 'field_agency_component_inf')) {
+      value = value.field_agency_component_inf;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(value, 'field_agency_component')) {
+      return false;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(value.field_agency_component, 'abbreviation')) {
+      return false;
+    }
+
+    return value.field_agency_component.abbreviation;
+  }
+
+  /**
+   * Build a unique row id from component data based on a given field.
+   *
+   * @param {string} fieldPath
+   *   A path to a value that is unique for the data in this object, in dot notation.
+   * @param {Object} flatRow
+   *   A component data object that has already been flattened (no nested arrays).
+   * @returns {string|boolean}
+   */
+  static buildRowId(fieldPath, flatRow) {
+    const parts = fieldPath.split('.');
+    let uniqueId = flatRow;
+    while (parts.length > 0) {
+      const field = parts.shift();
+      uniqueId = uniqueId[field] || null;
+      if (uniqueId === null) {
+        return false;
+      }
+    }
+    // In many cases, the field path will be only the component.
+    // There is no need to double that string in the key.
+    if (uniqueId !== flatRow.field_agency_component) {
+      uniqueId = `${flatRow.field_agency_component}_${uniqueId}`;
+    }
+
+    return uniqueId
+      .replace(/[^a-zA-Z0-9]/g, '_')
+      .toLowerCase();
+  }
+
+  /**
+   * Checks if a piece of raw data has nested arrays of data, and flattens
+   * the nested data if required.
+   *
+   * @param {Object} raw
+   *   Raw component data from a report field.
+   * @returns {{}[]|*[]}
+   */
+  static maybeFlatten(raw = {}) {
+    const shouldFlatten = Object.keys(raw).filter(key => Array.isArray(raw[key]));
+    if (shouldFlatten.length <= 0) {
+      return [raw];
+    }
+
+    return shouldFlatten.reduce((data, key) => (
+      data.concat(...FoiaAnnualReportUtilities.flatten(raw, key))
+    ), []);
+  }
+
+  /**
+   * Loops nested data in an objects field, merging (flattening) with the raw
+   * parent data.
+   *
+   * @param {Object} raw
+   *   An object containing nested data that needs to be flattened.
+   * @param {String} field
+   *   A field name in the raw data object that contains an array of values.
+   * @returns {{}[]|*}
+   */
+  static flatten(raw = {}, field) {
+    const data = raw[field] || false;
+    if (data === false) {
+      return [raw];
+    }
+
+    return data.map((value) => {
+      const newValue = Object.assign({}, raw);
+      newValue[field] = value;
+
+      return newValue;
+    });
+  }
+
+  /**
+   * Recurse into a data object, fixing text values from the drupal api where the field
+   * value is an object and the value that should be displayed is at {value: 'some value'}.
+   *
+   * @param {Object} data
+   *   A data object.
+   * @returns {{}|*}
+   */
+  static normalize(data) {
+    if (Array.isArray(data)) {
+      return data.map(value => FoiaAnnualReportUtilities.normalize(value));
+    }
+    if (data === null) {
+      return data;
+    }
+    if (typeof data !== 'object') {
+      return data;
+    }
+    if (Object.prototype.hasOwnProperty.call(data, 'value')) {
+      return data.value;
+    }
+
+    return Object.keys(data).reduce((normalized, key) => {
+      normalized[key] = FoiaAnnualReportUtilities.normalize(data[key]);
+
+      return normalized;
+    }, {});
+  }
+}
+
+export default FoiaAnnualReportUtilities;


### PR DESCRIPTION
* Adds a method to get component data rows and calls
that method when the results table is being built.
* Adds a method to build a list of selected agency abbreviations
per agency
* Adds a utility class to handle flattening and merging nested or
disparate component data into rows of objects.