### PR TITLE
FOIA-358: Only allow filtering on overall fields if only agency overall is selected.

### DIFF
--- a/js/util/foia_annual_report_request_builder.js
+++ b/js/util/foia_annual_report_request_builder.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { List } from 'immutable';
 import { JsonApi } from './json_api';
 import annualReportDataTypesStore from '../stores/annual_report_data_types';
+import FoiaAnnualReportFilterUtilities from './foia_annual_report_filter_utilities';
 
 class FoiaAnnualReportRequestBuilder extends JsonApi {
   constructor(baseUrl) {
@@ -63,11 +64,17 @@ class FoiaAnnualReportRequestBuilder extends JsonApi {
     return this;
   }
 
-  addDataTypeFiltersGroup(filters = []) {
+  addDataTypeFiltersGroup(filters = [], dataTypeId = '') {
     if (filters.length <= 0) {
       return this;
     }
-    let dataTypeFilters = filters;
+    let dataTypeFilters;
+    if (dataTypeId && FoiaAnnualReportFilterUtilities.filterOnOverallFields()) {
+      dataTypeFilters = FoiaAnnualReportFilterUtilities
+        .transformToOverallFilters(filters, dataTypeId);
+    } else {
+      dataTypeFilters = filters;
+    }
 
     // Transform the filters, adding an index which will be used when
     // naming the filter for the .request.filter() method and

--- a/www.foia.gov/api/annual-report-form/report_data_map.json
+++ b/www.foia.gov/api/annual-report-form/report_data_map.json
@@ -169,7 +169,7 @@
       {
         "id": "field_foia_requests_vb2.field_foia_req_vb2_info.field_num_relied_upon",
         "label": "Number of Times \"Other\" Reason Was Relied Upon",
-        "filter": true,
+        "filter": false,
         "overall_field": false,
         "display": true
       },
@@ -735,7 +735,7 @@
       {
         "id": "field_admin_app_vic3.field_admin_app_vic3_info.field_num_relied_upon",
         "label": "Number of Times \"Other\" Reason Was Relied Upon",
-        "filter": true,
+        "filter": false,
         "overall_field": false,
         "display": true
       },


### PR DESCRIPTION
Uses the helper functions to determine if there are no components selected (is true if the users selects all agencies or if they choose and agency, and unselect all components but overall) and replace filter fields with the appropriate overall field in the report request builder.