### PR TITLE
FOIA-358 Overall field display

### DIFF
--- a/js/components/foia_report_results_table.jsx
+++ b/js/components/foia_report_results_table.jsx
@@ -27,6 +27,7 @@ class FoiaReportResultsTable extends Component {
       data: tableData,
       columns: tableColumns,
       reactiveData: true,
+      layout: 'fitDataStretch',
     });
     if (this.props.displayMode === 'download' && this.props.tableData.length > 0) {
       this.downloadCSV();

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -201,11 +201,12 @@ class AnnualReportStore extends Store {
         ];
 
         const tables = [];
+        const isOverallOnly = FoiaAnnualReportFilterUtilities.filterOnOverallFields();
         selectedDataTypes.forEach((dataType) => {
           if (!tables.some(item => item.id === dataType.id)) {
             // Get our dataType-specific columns.
             const dataColumns = dataType.fields
-              .filter(field => field.display)
+              .filter(field => field.display && (!isOverallOnly || field.overall_field))
               .map(item => (
                 {
                   title: item.label,


### PR DESCRIPTION
Modifies the table header to only show fields that contain an overall field if only agency overall components appear in the selected agency.