### PR TITLE
FOIA-325: Additional fixes.

### DIFF
--- a/js/components/uswds_select_widget.jsx
+++ b/js/components/uswds_select_widget.jsx
@@ -25,7 +25,10 @@ const USWDSSelectWidget = props => (
 
 USWDSSelectWidget.propTypes = {
   name: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
   id: PropTypes.string.isRequired,
   value: PropTypes.string,
   handleChange: PropTypes.func,

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -13,7 +13,11 @@ function headingAsButton(cell) {
 
 function cellWithAria(cell) {
   const columnHeader = cell.getColumn().getDefinition().title;
-  return `<span aria-label="${columnHeader}: ${cell.getValue()}">${cell.getValue()}</span>`;
+  let cellValue = cell.getValue();
+  if (cellValue === undefined || cellValue === null) {
+    cellValue = '';
+  }
+  return `<span aria-label="${columnHeader}: ${cellValue}">${cellValue}</span>`;
 }
 
 class AnnualReportStore extends Store {


### PR DESCRIPTION
@bemarlan - found a couple of other issues whilst prepping for the demo:

- Makes the USWDSSelect widget accept either string or object for the title prop.
- Checks the cell value for table data cells for null or undefined and sets to empty string if they are.