### PR TITLE
FOIA-364: Report table cleanup.

### DIFF
--- a/js/components/foia_report_results_table.jsx
+++ b/js/components/foia_report_results_table.jsx
@@ -29,7 +29,6 @@ class FoiaReportResultsTable extends Component {
       columns: tableColumns,
       reactiveData: true,
       layout: 'fitDataStretch',
-      scrollToColumnPosition: 'center',
       tableBuilt: () => {
         const selector = `#${tableId} .tabulator-header button`;
         const buttons = document.querySelectorAll(selector);
@@ -52,8 +51,9 @@ class FoiaReportResultsTable extends Component {
   handleColumnFocus(event) {
     const button = event.target;
     const columnElement = button.closest('.tabulator-col');
+    columnElement.scrollLeft = 0;
     const tabulatorField = columnElement.getAttribute('tabulator-field');
-    this.tabulator.scrollToColumn(tabulatorField, 'middle', false);
+    this.tabulator.scrollToColumn(tabulatorField, 'right');
   }
 
   render() {

--- a/js/stores/annual_report.js
+++ b/js/stores/annual_report.js
@@ -202,7 +202,7 @@ class AnnualReportStore extends Store {
             titleFormatter: headingAsButton,
             formatter: cellWithAria,
             field: 'field_agency',
-            align: 'center',
+            align: 'left',
           },
           {
             title: 'Component',
@@ -233,7 +233,7 @@ class AnnualReportStore extends Store {
                   titleFormatter: headingAsButton,
                   formatter: cellWithAria,
                   field: item.id,
-                  align: 'center',
+                  align: item.filter ? 'center' : 'left',
                 }));
             const reportHeaders = defaultColumns.concat(dataColumns);
             const dataRows = this.getReportDataForType(dataType);


### PR DESCRIPTION
- Fixes so the table scrolling works better -- columns should not jump off the left side of the viewport now when tabbing through headers, and the table body should stay more closely in line with the headers when navigating backward using shift-tab.
- Added some logic to the headers to check if the field is filterable, and if so center, otherwise left align (the assumption is that all fields marked as not filterable are text fields). Long text columns are more readable when they are left aligned.